### PR TITLE
The RequestAdapter should use a completion block

### DIFF
--- a/Sources/NetworkingSession/Networking+RequestInterceptor.swift
+++ b/Sources/NetworkingSession/Networking+RequestInterceptor.swift
@@ -17,9 +17,8 @@ public protocol NetworkingRequestAdapter {
     /// - Parameters:
     ///   - urlRequest: Modify this `URLRequest` object if necessary. If no modifications are required simply return the `urlRequest`.
     ///   - session: This is the `URLSession` that the `urlRequest` will be sent over the wire on.
-    ///
-    /// - Returns: The `URLRequest` that is returned is what will be sent over the wire.
-    func adapt(urlRequest: URLRequest, for session: URLSession) -> URLRequest
+    ///   - completion: The `Result<URLRequest, Error>` will either fire off the passed in `URLRequest`, or throw the `Error`
+    func adapt(urlRequest: URLRequest, for session: URLSession, completion: @escaping (Result<URLRequest, Error>) -> Void)
 }
 
 public protocol NetworkingRequestRetrier: class {


### PR DESCRIPTION
The RequestAdapter should use a completion block to pass back an adapted URLRequest instead of returning. This allows you to perform an async task before having to pass back an adapted URLRequest