### PR TITLE
Feature/request retrier only needs to be used in the data task

### DIFF
--- a/Sources/NetworkingSession/Networking+Session+DataTask.swift
+++ b/Sources/NetworkingSession/Networking+Session+DataTask.swift
@@ -76,8 +76,7 @@ extension NetworkingSessionDataTask {
             guard let error = dataTaskResponseContainer.error ?? serializerResult.error,
                   let delegate = self.delegate,
                   let retrier = self.requestRetrier,
-                  let urlRequest = self.request,
-                  let urlResponse = dataTaskResponseContainer.response else {
+                  let urlRequest = self.request else {
 
                 queue.async { urlRequestCompletionHandler(serializerResult) }
                 return
@@ -86,7 +85,7 @@ extension NetworkingSessionDataTask {
             //If there is an error, we now ask the retrier if the failed request should be restarted or not
             retrier.retry(urlRequest: urlRequest,
                           dueTo: error,
-                          urlResponse: urlResponse,
+                          urlResponse: dataTaskResponseContainer.response ?? HTTPURLResponse(),
                           retryCount: self.retryCount) { retrierResult in
 
                 switch retrierResult {

--- a/Sources/NetworkingSession/Networking+Session+DataTask.swift
+++ b/Sources/NetworkingSession/Networking+Session+DataTask.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 internal protocol NetworkingSessionDataTaskDelegate: class {
+    func networkingSessionDataTaskIsReadyToExecute(networkingSessionDataTask: NetworkingSessionDataTask)
     func restart(urlRequest: URLRequest, accompaniedWith networkingSessionDataTask: NetworkingSessionDataTask)
 }
 
@@ -16,6 +17,7 @@ public class NetworkingSessionDataTask {
     internal var request: URLRequest?
     internal var dataTask: URLSessionDataTask? = nil
 
+    internal let urlRequestConvertibleError: Error?
     private(set) var retryCount = 0
     private weak var requestRetrier: NetworkingRequestRetrier?
     private weak var delegate: NetworkingSessionDataTaskDelegate?
@@ -24,25 +26,39 @@ public class NetworkingSessionDataTask {
 
     public var task: URLSessionTask? { dataTask }
 
-    internal init(request: URLRequest?,
+    internal init(requestConvertible: URLRequestConvertible?,
                   requestRetrier: NetworkingRequestRetrier? = nil,
-                  delegate: NetworkingSessionDataTaskDelegate? = nil) {
+                  delegate: NetworkingSessionDataTaskDelegate) {
 
         self.delegate = delegate
         self.requestRetrier = requestRetrier
-        self.request = request
+
+        do {
+            request = try requestConvertible?.asURLRequest()
+            urlRequestConvertibleError = nil
+        }
+        catch {
+            request = nil
+            urlRequestConvertibleError = error
+        }
     }
 
     @discardableResult
-    public func response<Serializer: NetworkingResponseSerializer>(serializer: Serializer,
-                                                                   runCompletionHandlerOn queue: DispatchQueue = .main,
-                                                                   completionHandler: @escaping (Result<Serializer.SerializedObject, Error>) -> Void) -> Self {
+    public func appendResponse<Serializer: NetworkingResponseSerializer>(serializer: Serializer,
+                                                                         runCompletionHandlerOn queue: DispatchQueue = .main,
+                                                                         completionHandler: @escaping (Result<Serializer.SerializedObject, Error>) -> Void) -> Self {
 
         let serializeResponseFunction = createSerializeResponseFunction(serializer: serializer,
                                                                         runUrlRequestCompletionHandlerOn: queue,
                                                                         urlRequestCompletionHandler: completionHandler)
         serializeResponses.append(serializeResponseFunction)
 
+        return self
+    }
+
+    @discardableResult
+    public func execute() -> NetworkingSessionDataTask {
+        delegate?.networkingSessionDataTaskIsReadyToExecute(networkingSessionDataTask: self)
         return self
     }
 

--- a/Sources/NetworkingSession/Networking+Session.swift
+++ b/Sources/NetworkingSession/Networking+Session.swift
@@ -62,7 +62,7 @@ extension NetworkingSession {
             execute(adaptedRequest ?? urlRequest, accompaniedWith: networkingSessionDataTask)
         }
         catch {
-            attemptToRetry(urlRequest: urlRequest, becauseOf: error, accompaniedWith: networkingSessionDataTask)
+            executeResponseSerializers(on: networkingSessionDataTask, becauseOf: error)
         }
     }
 
@@ -76,27 +76,6 @@ extension NetworkingSession {
 
         networkingSessionDataTask.dataTask = dataTask
         dataTask.resume()
-    }
-
-    private func attemptToRetry(urlRequest: URLRequest, becauseOf error: Error, accompaniedWith networkingSessionDataTask: NetworkingSessionDataTask) {
-        guard let requestRetrier = requestRetrier else {
-            executeResponseSerializers(on: networkingSessionDataTask, becauseOf: error)
-            return
-        }
-
-        requestRetrier.retry(urlRequest: urlRequest,
-                             dueTo: error,
-                             urlResponse: HTTPURLResponse(),
-                             retryCount: networkingSessionDataTask.retryCount) { retryResult in
-            switch retryResult {
-                case .doNotRetry:
-                    self.executeResponseSerializers(on: networkingSessionDataTask, becauseOf: error)
-
-                case .retry:
-                    networkingSessionDataTask.incrementRetryCount()
-                    self.start(urlRequest, accompaniedWith: networkingSessionDataTask)
-            }
-        }
     }
 
     private func executeResponseSerializers(on networkingSessionDataTask: NetworkingSessionDataTask, becauseOf error: Error?) {

--- a/Sources/Route/Networking+Route+Extensions.swift
+++ b/Sources/Route/Networking+Route+Extensions.swift
@@ -45,8 +45,9 @@ extension NetworkingRoute {
     @discardableResult
     public func request(completion: @escaping (Result<ResponseSerializer.SerializedObject, Error>) -> Void) -> URLSessionTask? {
         return session
-            .start(request: self)
-            .response(serializer: responseSerializer, runCompletionHandlerOn: .main, completionHandler: completion)
+            .createDataTask(from: self)
+            .appendResponse(serializer: responseSerializer, runCompletionHandlerOn: .main, completionHandler: completion)
+            .execute()
             .task
     }
 }


### PR DESCRIPTION
There was a potential race case between executing and appending response serializers. This would lead to the completion block for a request to never be called. I added an execute() function to the NetworkingSessionDataTask. Call execute() after you have appended all of your response serializers.