### PR TITLE
NetworkingRoute now has a mockResponse property

### DIFF
--- a/Sources/NetworkingSession/Networking+Session+DataTask.swift
+++ b/Sources/NetworkingSession/Networking+Session+DataTask.swift
@@ -47,11 +47,11 @@ public class NetworkingSessionDataTask: Cancellable {
     }
 
     @discardableResult
-    public func serializeResponse<ResponseSerializer: NetworkingResponseSerializer>(with responseSerializationMode: NetworkingResponseSerializationMode<ResponseSerializer>,
+    public func serializeResponse<ResponseSerializer: NetworkingResponseSerializer>(with responseSerializer: ResponseSerializer,
                                                                                     runCompletionHandlerOn queue: DispatchQueue = .main,
                                                                                     completionHandler: @escaping (Result<ResponseSerializer.SerializedObject, Error>) -> Void) -> Self {
 
-        queueResponseSerialization(serialize: responseSerializationMode.serialize,
+        queueResponseSerialization(serialize: responseSerializer.serialize,
                                    runUrlRequestCompletionHandlerOn: queue,
                                    urlRequestCompletionHandler: completionHandler)
         return self

--- a/Sources/Route/Networking+Route.swift
+++ b/Sources/Route/Networking+Route.swift
@@ -27,7 +27,8 @@ public protocol NetworkingRoute: URLRequestConvertible {
 
     //--Response Handling--//
     associatedtype ResponseSerializer: NetworkingResponseSerializer
-    var responseSerializationMode: NetworkingResponseSerializationMode<ResponseSerializer> { get }
+    var responseSerializer: ResponseSerializer { get }
+    var mockResponse: Result<ResponseSerializer.SerializedObject, Error>? { get }
 
     ///Responsible for turning a NetworkingRoute object into a Result<ResponseSerializer.SerializedObject, Error>
     func request(completion: @escaping (Result<ResponseSerializer.SerializedObject, Error>) -> Void) -> Cancellable
@@ -46,23 +47,6 @@ public enum NetworkingRouteHttpMethod: String {
     case delete
     case put
     case patch
-}
-
-public enum NetworkingResponseSerializationMode<ResponseSerializer: NetworkingResponseSerializer> {
-
-    /// Utilitizes the passed in `ResponseSerializer`.
-    case standard(ResponseSerializer)
-    /// Allows you to override a `NetworkingResponseSerializer`'s `serialize` function. This is helpful for mocking networking responses. Use this for debugging/testing purposes.
-    case override((NetworkingRawResponse) -> Result<ResponseSerializer.SerializedObject, Error>)
-
-    internal var serialize: (NetworkingRawResponse) -> Result<ResponseSerializer.SerializedObject, Error> {
-        switch self {
-            case .standard(let serializer):
-                return serializer.serialize
-            case .override(let overridenSerialization):
-                return overridenSerialization
-        }
-    }
 }
 
 /// Potential errors that can be returned when attempting to create a `URLRequest` from a `NetworkingRoute`
@@ -86,4 +70,8 @@ public struct NetworkingRawResponse {
     public let urlResponse: HTTPURLResponse?
     public let data: Data?
     public let error: Error?
+}
+
+public struct MockedCancellable: Cancellable {
+    public func cancel() {}
 }


### PR DESCRIPTION
If `mockResponse` is not nil, then the mocked response is what will be returned.