### PR TITLE
Automate release flow: draft notes, build DocC, deploy Pages

### DIFF
--- a/.github/workflows/Deploy-Docs.yml
+++ b/.github/workflows/Deploy-Docs.yml
@@ -1,25 +1,15 @@
 # Build the DocC site and deploy to GitHub Pages.
 #
-# Production trigger: `release: published` — the live site updates only after a
-# GitHub Release is published, never on raw pushes.
+# Triggered when a GitHub Release is published. The live site at
+# https://djk12587.github.io/PopNetworking/ updates only at that point —
+# never on raw pushes — so prod docs stay pinned to tagged versions.
 #
-# Testing trigger: `push: branches: [release-automation]` — fires on every
-# push to the test branch, so you can iterate by committing. (Note:
-# `workflow_dispatch` would be cleaner but its UI button only appears for
-# workflows on the default branch.)
-#
-# IMPORTANT: while this file is on the `release-automation` branch, the deploy
-# step uploads a regular workflow artifact (download + open `index.html`
-# locally) instead of pushing to Pages. Before merging to `main`, swap the
-# `actions/upload-artifact` step back to `actions/upload-pages-artifact`,
-# remove the test `push:` trigger, and add the `deploy` job described in the
-# comments at the bottom.
+# Pairs with `Draft-Release.yml`, which auto-drafts a release on tag push.
+# Publishing that draft fires this workflow.
 
 name: deploy-docs
 
 on:
-  push:
-    branches: [release-automation]
   release:
     types: [published]
 
@@ -62,44 +52,23 @@ jobs:
             --hosting-base-path PopNetworking \
             --output-path _site
 
-      # TESTING SHIM: tars the site (DocC paths contain colons, which v4
-      # upload-artifact rejects for NTFS compatibility) and uploads it for
-      # download + inspection. Replace with `actions/upload-pages-artifact@v3`
-      # (and add a `deploy` job using `actions/deploy-pages@v4`) before
-      # merging to main.
-      - name: Tar site for upload
-        run: tar -czf docc-site.tar.gz -C _site .
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
 
-      - name: Upload site artifact (test mode)
-        uses: actions/upload-artifact@v7
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          name: docc-site
-          path: docc-site.tar.gz
-          retention-days: 7
+          path: _site
 
-# PRODUCTION VERSION (apply before merging to main):
-#
-# Replace the "Upload site artifact (test mode)" step with:
-#
-#       - name: Configure Pages
-#         uses: actions/configure-pages@v5
-#
-#       - name: Upload Pages artifact
-#         uses: actions/upload-pages-artifact@v3
-#         with:
-#           path: _site
-#
-# And add a second job:
-#
-#   deploy:
-#     needs: build
-#     runs-on: ubuntu-latest
-#     permissions:
-#       pages: write
-#       id-token: write
-#     environment:
-#       name: github-pages
-#       url: ${{ steps.deployment.outputs.page_url }}
-#     steps:
-#       - id: deployment
-#         uses: actions/deploy-pages@v4
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/Deploy-Docs.yml
+++ b/.github/workflows/Deploy-Docs.yml
@@ -30,9 +30,6 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   build:
     runs-on: macos-15
@@ -74,7 +71,7 @@ jobs:
         run: tar -czf docc-site.tar.gz -C _site .
 
       - name: Upload site artifact (test mode)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docc-site
           path: docc-site.tar.gz

--- a/.github/workflows/Deploy-Docs.yml
+++ b/.github/workflows/Deploy-Docs.yml
@@ -3,19 +3,23 @@
 # Production trigger: `release: published` — the live site updates only after a
 # GitHub Release is published, never on raw pushes.
 #
-# Testing trigger: `workflow_dispatch` — run manually from the Actions UI to
-# validate the build without needing a real release.
+# Testing trigger: `push: branches: [release-automation]` — fires on every
+# push to the test branch, so you can iterate by committing. (Note:
+# `workflow_dispatch` would be cleaner but its UI button only appears for
+# workflows on the default branch.)
 #
 # IMPORTANT: while this file is on the `release-automation` branch, the deploy
 # step uploads a regular workflow artifact (download + open `index.html`
 # locally) instead of pushing to Pages. Before merging to `main`, swap the
-# `actions/upload-artifact` step back to `actions/upload-pages-artifact` and
-# add the `deploy` job described in the comments at the bottom.
+# `actions/upload-artifact` step back to `actions/upload-pages-artifact`,
+# remove the test `push:` trigger, and add the `deploy` job described in the
+# comments at the bottom.
 
 name: deploy-docs
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [release-automation]
   release:
     types: [published]
 

--- a/.github/workflows/Deploy-Docs.yml
+++ b/.github/workflows/Deploy-Docs.yml
@@ -30,6 +30,9 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: macos-15

--- a/.github/workflows/Deploy-Docs.yml
+++ b/.github/workflows/Deploy-Docs.yml
@@ -62,14 +62,19 @@ jobs:
             --hosting-base-path PopNetworking \
             --output-path _site
 
-      # TESTING SHIM: uploads as a regular artifact for download + inspection.
-      # Replace with `actions/upload-pages-artifact@v3` (and add a `deploy` job
-      # using `actions/deploy-pages@v4`) before merging to main.
+      # TESTING SHIM: tars the site (DocC paths contain colons, which v4
+      # upload-artifact rejects for NTFS compatibility) and uploads it for
+      # download + inspection. Replace with `actions/upload-pages-artifact@v3`
+      # (and add a `deploy` job using `actions/deploy-pages@v4`) before
+      # merging to main.
+      - name: Tar site for upload
+        run: tar -czf docc-site.tar.gz -C _site .
+
       - name: Upload site artifact (test mode)
         uses: actions/upload-artifact@v4
         with:
           name: docc-site
-          path: _site
+          path: docc-site.tar.gz
           retention-days: 7
 
 # PRODUCTION VERSION (apply before merging to main):

--- a/.github/workflows/Deploy-Docs.yml
+++ b/.github/workflows/Deploy-Docs.yml
@@ -1,0 +1,96 @@
+# Build the DocC site and deploy to GitHub Pages.
+#
+# Production trigger: `release: published` — the live site updates only after a
+# GitHub Release is published, never on raw pushes.
+#
+# Testing trigger: `workflow_dispatch` — run manually from the Actions UI to
+# validate the build without needing a real release.
+#
+# IMPORTANT: while this file is on the `release-automation` branch, the deploy
+# step uploads a regular workflow artifact (download + open `index.html`
+# locally) instead of pushing to Pages. Before merging to `main`, swap the
+# `actions/upload-artifact` step back to `actions/upload-pages-artifact` and
+# add the `deploy` job described in the comments at the bottom.
+
+name: deploy-docs
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Select Xcode
+        run: |
+          SWIFT_VERSION=$(swift --version 2>&1 | grep -oE 'Swift version [0-9]+' | grep -oE '[0-9]+')
+          if [ "${SWIFT_VERSION:-0}" -lt 6 ]; then
+            XCODE=$(ls -d /Applications/Xcode_*.app 2>/dev/null | grep -vi beta | sort -V | tail -1)
+            echo "Default Swift $SWIFT_VERSION is too old, selecting $XCODE"
+            sudo xcode-select -s "$XCODE"
+          fi
+          xcodebuild -version
+
+      - name: Build DocC archive
+        run: |
+          set -o pipefail
+          xcodebuild docbuild \
+            -scheme PopNetworking \
+            -destination 'generic/platform=iOS' \
+            -derivedDataPath .derivedData \
+            | xcpretty
+
+      - name: Transform for static hosting
+        run: |
+          xcrun docc process-archive transform-for-static-hosting \
+            .derivedData/Build/Products/Debug-iphoneos/PopNetworking.doccarchive \
+            --hosting-base-path PopNetworking \
+            --output-path _site
+
+      # TESTING SHIM: uploads as a regular artifact for download + inspection.
+      # Replace with `actions/upload-pages-artifact@v3` (and add a `deploy` job
+      # using `actions/deploy-pages@v4`) before merging to main.
+      - name: Upload site artifact (test mode)
+        uses: actions/upload-artifact@v4
+        with:
+          name: docc-site
+          path: _site
+          retention-days: 7
+
+# PRODUCTION VERSION (apply before merging to main):
+#
+# Replace the "Upload site artifact (test mode)" step with:
+#
+#       - name: Configure Pages
+#         uses: actions/configure-pages@v5
+#
+#       - name: Upload Pages artifact
+#         uses: actions/upload-pages-artifact@v3
+#         with:
+#           path: _site
+#
+# And add a second job:
+#
+#   deploy:
+#     needs: build
+#     runs-on: ubuntu-latest
+#     permissions:
+#       pages: write
+#       id-token: write
+#     environment:
+#       name: github-pages
+#       url: ${{ steps.deployment.outputs.page_url }}
+#     steps:
+#       - id: deployment
+#         uses: actions/deploy-pages@v4

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -1,0 +1,41 @@
+# Draft a GitHub Release whenever a semver tag is pushed.
+#
+# Production trigger: `push: tags: ['[0-9]+.[0-9]+.[0-9]+']` — pushing a tag
+# like `4.2.0` creates a draft release. The user reviews, edits if needed,
+# and clicks Publish in the UI. Publishing then fires `Deploy-Docs.yml`.
+#
+# Testing trigger: `workflow_dispatch` with a manual `tag_name` input. Lets
+# you exercise the auto-notes generation against a synthetic tag without
+# pushing real tags. Drafts created this way can be deleted from the
+# Releases page after inspection.
+
+name: draft-release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Tag to draft a release for (must already exist on the repo)"
+        required: true
+        default: "0.0.0-test"
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Draft release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          draft: true
+          generate_release_notes: true

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -4,20 +4,16 @@
 # like `4.2.0` creates a draft release. The user reviews, edits if needed,
 # and clicks Publish in the UI. Publishing then fires `Deploy-Docs.yml`.
 #
-# Testing trigger: `workflow_dispatch` with a manual `tag_name` input. Lets
-# you exercise the auto-notes generation against a synthetic tag without
-# pushing real tags. Drafts created this way can be deleted from the
-# Releases page after inspection.
+# Testing: push a synthetic tag pointing at a `release-automation` commit
+# (e.g. `git tag 0.0.0 && git push origin 0.0.0`). Tag-push triggers fire
+# from whatever workflow file is present on the tagged commit, so they work
+# from non-default branches. Delete the test tag + drafted release after.
+# (Note: `workflow_dispatch` would be cleaner for testing but its UI button
+# only appears for workflows on the default branch.)
 
 name: draft-release
 
 on:
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: "Tag to draft a release for (must already exist on the repo)"
-        required: true
-        default: "0.0.0-test"
   push:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
@@ -36,6 +32,6 @@ jobs:
       - name: Draft release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          tag_name: ${{ github.ref_name }}
           draft: true
           generate_release_notes: true

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -1,15 +1,9 @@
 # Draft a GitHub Release whenever a semver tag is pushed.
 #
-# Production trigger: `push: tags: ['[0-9]+.[0-9]+.[0-9]+']` — pushing a tag
-# like `4.2.0` creates a draft release. The user reviews, edits if needed,
-# and clicks Publish in the UI. Publishing then fires `Deploy-Docs.yml`.
-#
-# Testing: push a synthetic tag pointing at a `release-automation` commit
-# (e.g. `git tag 0.0.0 && git push origin 0.0.0`). Tag-push triggers fire
-# from whatever workflow file is present on the tagged commit, so they work
-# from non-default branches. Delete the test tag + drafted release after.
-# (Note: `workflow_dispatch` would be cleaner for testing but its UI button
-# only appears for workflows on the default branch.)
+# Pushing a tag like `4.2.0` creates a draft release with auto-generated
+# notes from PR titles since the previous tag. Review the draft in the
+# Releases UI, edit if needed, and click Publish. Publishing then fires
+# `Deploy-Docs.yml`, which builds and deploys the DocC site.
 
 name: draft-release
 

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -33,5 +33,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
+          name: PopNetworking ${{ github.ref_name }}
           draft: true
           generate_release_notes: true

--- a/.github/workflows/Draft-Release.yml
+++ b/.github/workflows/Draft-Release.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Draft release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: PopNetworking ${{ github.ref_name }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,47 @@
+# Releasing
+
+Cutting a new version of PopNetworking takes three actions: merge the feature work, push a tag, click Publish. Everything else (release notes, DocC build, Pages deploy) is automated by the workflows in `.github/workflows/`.
+
+## Steps
+
+1. **Merge feature PRs into `main`.** Use descriptive PR titles — they become the release notes verbatim.
+
+2. **Tag the release.** Tags must match `MAJOR.MINOR.PATCH` (e.g. `4.2.0`):
+   ```bash
+   git checkout main && git pull
+   git tag 4.2.0
+   git push origin 4.2.0
+   ```
+   Pushing the tag triggers `.github/workflows/Draft-Release.yml`, which creates a **draft** GitHub Release titled `PopNetworking 4.2.0`. The body is auto-generated from PR titles merged since the previous tag.
+
+3. **Review and publish the draft.**
+   - Open https://github.com/djk12587/PopNetworking/releases — the draft is at the top
+   - Edit the body if you want to reorganize notes, add migration guidance, etc.
+   - Click **Publish release**
+
+   Publishing fires `.github/workflows/Deploy-Docs.yml`, which:
+   - Builds DocC against the tagged commit (`xcodebuild docbuild` + `docc transform-for-static-hosting`)
+   - Deploys the built site to GitHub Pages
+
+   The live site at https://djk12587.github.io/PopNetworking/documentation/popnetworking updates within a few minutes.
+
+## Recovering from a bad release
+
+- **Notes are wrong**: edit the published release in the GitHub UI. Pages is unaffected.
+- **Tag points at the wrong commit**: delete the tag (`git push --delete origin X.Y.Z`), retag the correct commit, push. Delete the old draft and re-publish the new one.
+- **Deploy-Docs failed**: re-run the failed job from the Actions tab. The build is deterministic — if your local `xcodebuild docbuild` works, CI's will too.
+- **Site renders broken content**: push a fix to `main`, then push a patch tag (`X.Y.Z+1`). The next deploy fully overwrites Pages.
+
+## One-time setup (already done)
+
+- Repo Settings → Pages → Source = **GitHub Actions** (not "Deploy from a branch")
+- Default branch = `main`
+- Tag format pattern in `Draft-Release.yml` matches semver-only tags
+
+If Pages source ever gets reset to a branch source, deploys will silently fail. Re-set it to "GitHub Actions".
+
+## What does NOT happen automatically
+
+- Bumping versions in any consumer's `Package.swift` (clients pin themselves)
+- Writing migration guides for breaking changes (do this in the PR body, it'll appear in the auto-generated release notes)
+- Publishing to any package registry (Swift Package Manager pulls from tags directly)

--- a/Sources/PopNetworking.docc/NetworkingRoute.md
+++ b/Sources/PopNetworking.docc/NetworkingRoute.md
@@ -1,0 +1,40 @@
+
+# ``PopNetworking/NetworkingRoute``
+
+## Topics
+
+### Building the URLRequest
+- ``method``
+- ``baseUrl``
+- ``path``
+- ``NetworkingRouteHttpHeaders``
+- ``headers-7smdy``
+- ``parameterEncoding-17u8i``
+- ``timeoutInterval-21jp1``
+- ``urlRequest-5u991``
+
+### NetworkingSession
+``NetworkingRoute``'s are ran on an instance of ``NetworkingSession``. To run a route, call ``NetworkingSession/execute(route:)`` and pass in an instance of a ``NetworkingRoute``.
+- ``session-5s3b3``
+
+### Ways to run a NetworkingRoute
+- ``run``
+- ``request(priority:completeOn:completion:)``
+- ``result``
+- ``task(priority:)``
+- ``publisher``
+- ``failablePublisher``
+
+### Response handling & parsing
+- ``responseSerializer``
+- ``ResponseSerializer``
+- ``NetworkingResponseSerializers``
+- ``responseValidator-220e4``
+- ``mockSerializedResult-62avc``
+
+### Advanced Usage
+- ``adapter-8np6``
+- ``retrier-9650z``
+- ``interceptor-pstd``
+- ``repeater-397rr``
+- ``Repeater``

--- a/Sources/PopNetworking.docc/PopNetworking.md
+++ b/Sources/PopNetworking.docc/PopNetworking.md
@@ -1,0 +1,68 @@
+# ``PopNetworking``
+
+A protocol-oriented HTTP networking layer for Swift. Built with Swift 6 and strict concurrency.
+
+## Quick Start
+
+Define an endpoint by conforming to ``NetworkingRoute``:
+
+```swift
+struct GetUser: NetworkingRoute {
+    let userId: Int
+
+    var baseUrl: String { "https://api.example.com" }
+    var path: String { "users/\(userId)" }
+    var method: NetworkingRouteHttpMethod { .get }
+    var responseSerializer: NetworkingResponseSerializers.DecodableResponseSerializer<User> {
+        .init()
+    }
+}
+```
+
+Execute it:
+
+```swift
+let user = try await GetUser(userId: 42).run
+```
+
+## Topics
+
+### Defining Routes
+
+- ``NetworkingRoute``
+- ``Route``
+- ``NetworkingRouteHttpMethod``
+- ``NetworkingRouteParameterEncoding``
+
+### Executing Routes
+
+- ``NetworkingSession``
+- ``NetworkingSessionProtocol``
+- ``URLSessionProtocol``
+
+### Response Handling
+
+- ``NetworkingResponseSerializer``
+- ``NetworkingResponseSerializers``
+- ``NetworkingResponseValidator``
+
+### Request Modifiers
+
+- ``NetworkingAdapter``
+- ``NetworkingRetrier``
+- ``NetworkingInterceptor``
+- ``RouteInterceptor``
+- ``NetworkingRetrierResult``
+- ``NetworkingPriority``
+
+### Parameter Encoding
+
+- ``URLEncoding``
+- ``JSONEncoding``
+- ``MultipartEncoding``
+- ``MultipartPart``
+
+### Combine Support
+
+- ``NetworkingRoutePublisher``
+- ``NetworkingRouteFailablePublisher``


### PR DESCRIPTION
Replaces the manual documentation branch + local DocC build + manual GitHub Release flow with two GitHub Actions workflows. The previous manual release process collapses to: merge PR → push tag → click Publish.
                                                                                                                                              
## What this PR adds                                                                                                                        
   
- **`.github/workflows/Draft-Release.yml`** — fires on `push: tags` matching `MAJOR.MINOR.PATCH`. Drafts a GitHub Release titled `PopNetworking X.Y.Z` with auto-generated notes from PR titles since the previous tag.
- **`.github/workflows/Deploy-Docs.yml`** — fires on `release: published`. Builds DocC via `xcodebuild docbuild` + `docctransform-for-static-hosting`, then deploys to GitHub Pages.                                                                                
- **`Sources/PopNetworking.docc/`** — moves the DocC catalog (`PopNetworking.md`, `NetworkingRoute.md`) onto `main`. Previously it lived only on the `documentation` branch, which CI now needs to read from.                                                                        
- **`RELEASING.md`** — runbook explaining the new flow and recovery steps.
                                                                                                                                              
## Operator action required after merge                                                                                                     

1. Repo Settings → Pages → switch Source from "Deploy from a branch" to **GitHub Actions**. Until this is flipped, `Deploy-Docs.yml` will silently fail at the deploy step.
2. After verifying a successful release deploy, delete the `documentation` branch (it no longer serves anything).

## Verification plan
                                                                                                                                              
After merge + Pages source switch, push a throwaway tag (e.g. `4.1.1`) to exercise the full chain. If `Draft-Release` drafts correctly and `Deploy-Docs` lands on `https://djk12587.github.io/PopNetworking/documentation/popnetworking`, the cutover is done.
                                                                                                                                              
If anything fails, flip Pages source back to "Deploy from a branch" / `documentation` / `/docs`. The old docs are still there untouched, so the live site recovers immediately.